### PR TITLE
Use `clj-chrome-devtools` for ClojureScript testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/clojure:lein-2.8.1-browsers
+    environment:
+      JVM_OPTS: -Xmx3200m
+    steps:
+      - checkout
+      - restore_cache:
+          key: stylefy-{{ checksum "project.clj" }}
+      - run: lein deps
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: stylefy-{{ checksum "project.clj" }}
+      - run: lein test

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -1,7 +1,7 @@
 # Run tests
 
 ```bash
-lein doo phantom test
+lein test
 ```
 
 # Compile examples project

--- a/project.clj
+++ b/project.clj
@@ -1,24 +1,22 @@
 (defproject stylefy "1.2.0"
   :description "Library for styling UI components"
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.542"]
-                 [prismatic/dommy "1.1.0"]
-                 [reagent "0.6.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/clojurescript "1.9.946"]
+                 [reagent "0.7.0"]
                  [garden "1.3.2"]]
   :plugins [[lein-cljsbuild "1.1.2"]
             [lein-doo "0.1.7"]
             [lein-codox "0.10.3"]]
+  :profiles {:dev {:dependencies [[prismatic/dommy "1.1.0"]
+                                  [clj-chrome-devtools "20180310"]]}}
   :codox {:language :clojurescript
           :output-path "doc"
           :source-paths ["src"]}
   :cljsbuild {:builds [{:id "test"
                         :source-paths ["src" "test"]
                         :compiler {:output-to "target/cljs/test/test.js"
-                                   :output-dir "target/cljs/test"
-                                   :optimizations :none
-                                   :pretty-print true
-                                   :source-map true
-                                   :main stylefy.runner}}
+                                   :optimizations :whitespace
+                                   :pretty-print true}}
                        {:id "prod"
                         :source-paths ["src"]
                         :compiler {:output-to "stylefy.js"

--- a/project.clj
+++ b/project.clj
@@ -2,13 +2,13 @@
   :description "Library for styling UI components"
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.9.946"]
+                 [prismatic/dommy "1.1.0"]
                  [reagent "0.7.0"]
                  [garden "1.3.2"]]
   :plugins [[lein-cljsbuild "1.1.2"]
             [lein-doo "0.1.7"]
             [lein-codox "0.10.3"]]
-  :profiles {:dev {:dependencies [[prismatic/dommy "1.1.0"]
-                                  [clj-chrome-devtools "20180310"]]}}
+  :profiles {:dev {:dependencies [[clj-chrome-devtools "20180310"]]}}
   :codox {:language :clojurescript
           :output-path "doc"
           :source-paths ["src"]}

--- a/test/stylefy/chrome_test.clj
+++ b/test/stylefy/chrome_test.clj
@@ -1,0 +1,10 @@
+(ns stylefy.chrome-test
+  (:require  [clojure.test :refer [deftest]]
+             [clj-chrome-devtools.cljs.test :refer [build-and-test]]))
+
+
+(deftest chrome-test
+  (build-and-test "test"
+                  '[stylefy.tests.core-test
+                    stylefy.tests.styles-test
+                    stylefy.tests.dom-test]))

--- a/test/stylefy/runner.cljs
+++ b/test/stylefy/runner.cljs
@@ -1,9 +1,0 @@
-(ns stylefy.runner
-  (:require [doo.runner :refer-macros [doo-tests]]
-            [stylefy.tests.core-test :as core]
-            [stylefy.tests.styles-test :as styles]
-            [stylefy.tests.dom-test :as dom]))
-
-(doo-tests 'stylefy.tests.core-test
-           'stylefy.tests.styles-test
-           'stylefy.tests.dom-test)

--- a/test/stylefy/tests/core_test.cljs
+++ b/test/stylefy/tests/core_test.cljs
@@ -253,26 +253,24 @@
          {::stylefy.impl.dom/class-name "background-transition"
           ::stylefy.impl.dom/class-properties {:transition "background-color 1s;"}})))
 
-(comment
-  ;; TODO Passes locally, but not on Circle!?
-  (deftest prepare-styles
-    (testing "Good argument"
-      (try
-        (stylefy/prepare-styles [{:foo :bar} nil {:foo :bar}])
-        (is true "Error was not thrown as expected")
-        (catch js/Error e
-          (is false "Error was thrown"))))
+(deftest prepare-styles
+  (testing "Good argument"
+    (try
+      (stylefy/prepare-styles [{:foo :bar} nil {:foo :bar}])
+      (is true "Error was not thrown as expected")
+      (catch js/Error e
+        (is false "Error was thrown"))))
 
-    (testing "Good empty argument"
-      (try
-        (stylefy/prepare-styles [])
-        (is true "Error was not thrown as expected")
-        (catch js/Error e
-          (is false "Error was thrown"))))
+  (testing "Good empty argument"
+    (try
+      (stylefy/prepare-styles [])
+      (is true "Error was not thrown as expected")
+      (catch js/Error e
+        (is false "Error was thrown"))))
 
-    (testing "Bad argument: map"
-      (try
-        (stylefy/prepare-styles {:foo :bar})
-        (is false "Expected an error to be thrown.")
-        (catch js/Error e
-          (is true "Error was thrown as expected"))))))
+  (testing "Bad argument: map"
+    (try
+      (stylefy/prepare-styles {:foo :bar})
+      (is false "Expected an error to be thrown.")
+      (catch js/Error e
+        (is true "Error was thrown as expected")))))


### PR DESCRIPTION
As PhantomJS is at the end of its life, I changed the testing to run on headless chrome with clj-chrome-devtools.

Changes:
- Upgrade deps
- Configure test build for clj-chrome-devtools testing
- Remove doo runner and add clj test runner
- Moved to CircleCI 2.0 configuration.
- Uncomment some commented out tests

Tried it out with CircleCI and the tests pass, one weird thing is the amount of assertions made differs.
