### PR TITLE
Implement with-classes for both style and option maps

### DIFF
--- a/src/stylefy/impl/styles.cljs
+++ b/src/stylefy/impl/styles.cljs
@@ -30,7 +30,7 @@
     (create-style! {:props sub-style :hash (hash-style sub-style)})))
 
 (defn- style-return-value [style style-hash options]
-  (let [with-classes (:stylefy.core/with-classes options)
+  (let [with-classes (:stylefy.core/with-classes style)
         html-attributes (utils/filter-props options)
         html-attributes-class (:class html-attributes)
         html-attributes-inline-style (:style html-attributes)]
@@ -82,7 +82,7 @@
   @dom/styles-in-use
 
   (when-not (empty? style)
-    (let [with-classes (:stylefy.core/with-classes options)]
+    (let [with-classes (:stylefy.core/with-classes style)]
 
       (assert (or (nil? with-classes)
                   (and (vector? with-classes)

--- a/src/stylefy/impl/styles.cljs
+++ b/src/stylefy/impl/styles.cljs
@@ -30,7 +30,8 @@
     (create-style! {:props sub-style :hash (hash-style sub-style)})))
 
 (defn- style-return-value [style style-hash options]
-  (let [with-classes (:stylefy.core/with-classes style)
+  (let [with-classes (vec (concat (:stylefy.core/with-classes style)
+                                  (:stylefy.core/with-classes options)))
         html-attributes (utils/filter-props options)
         html-attributes-class (:class html-attributes)
         html-attributes-inline-style (:style html-attributes)]
@@ -82,7 +83,8 @@
   @dom/styles-in-use
 
   (when-not (empty? style)
-    (let [with-classes (:stylefy.core/with-classes style)]
+    (let [with-classes (vec (concat (:stylefy.core/with-classes style)
+                                    (:stylefy.core/with-classes options)))]
 
       (assert (or (nil? with-classes)
                   (and (vector? with-classes)


### PR DESCRIPTION
This should be be backwards compatible for those people that have the with-classes on the option map.