### PR TITLE
Ability to input dom-node as root for stylefy's style-tags on init.

### DIFF
--- a/src/stylefy/core.cljs
+++ b/src/stylefy/core.cljs
@@ -104,6 +104,7 @@
   ([] (init {}))
   ([options]
    (impl-styles/init-custom-class-prefix options)
+   (dom/init-stylefy-root-node options)
    (dom/init-cache options)
    (impl-styles/init-global-vendor-prefixes options)
    (reset! dom/stylefy-initialised? true)))


### PR DESCRIPTION
Stylefy tries to locate specific style-tags from the document head. This is problematic when creating webcomponents and using shadow-dom because the shadow-dom content does not have visibility to styles inside document's head.

This problem can be solved by having the ability to give a root-tag of the style-tags for Stylefy on init.