### PR TITLE
Stores keyframes in a map to avoid duplication

### DIFF
--- a/test/stylefy/tests/core_test.cljs
+++ b/test/stylefy/tests/core_test.cljs
@@ -327,6 +327,41 @@
                                   {:background-color "blue"}]))
          "@keyframes simple-animation{from{background-color:red}to{background-color:blue}}")))
 
+(deftest update-keyframes
+  (reset! stylefy.impl.dom/keyframes-in-use {})
+  (stylefy/keyframes "animation-a"
+                     [:from
+                      {:background-color "red"}]
+                     [:to
+                      {:background-color "blue"}])
+
+  (stylefy/keyframes "animation-a"
+                     [:from
+                      {:background-color "blue"}]
+                     [:to
+                      {:background-color "red"}])
+
+  (stylefy/keyframes "animation-b"
+                     [:from
+                      {:background-color "blue"}]
+                     [:to
+                      {:background-color "red"}])
+
+  (is (= (count (keys @stylefy.impl.dom/keyframes-in-use))
+         2))
+
+  (is (= @stylefy.impl.dom/keyframes-in-use
+         {"animation-a" (css (stylefy/keyframes "animation-a"
+                                                [:from
+                                                 {:background-color "blue"}]
+                                                [:to
+                                                 {:background-color "red"}]))
+          "animation-b" (css (stylefy/keyframes "animation-b"
+                                                [:from
+                                                 {:background-color "blue"}]
+                                                [:to
+                                                 {:background-color "red"}]))})))
+
 (deftest tag
   (reset! stylefy.impl.dom/custom-tags-in-use [])
   (is (= (stylefy/tag "code"


### PR DESCRIPTION
Currently the implementation of the `keyframes` function will result
in duplicate entries should the function be called multiple times with
the same identifier. I noticed this during an intractive figwheel
session as I was iterating on some animations where I had numerous
duplicate keyframes.